### PR TITLE
:arrow_up: Pin pydantic to >1.8.2,<2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,7 @@ dependencies:
   - psycopg2
   - python-dotenv
   - python==3.9.*
-  - pydantic==1.*
+  - pydantic>=1.8.2,<2.0.0
   - scipy
   - scikit-learn==0.24
   - sqlalchemy==1.4.41


### PR DESCRIPTION
sqlmodel version 0.0.8 requires pydantic versions greater than 1.8.2 and less than 2.

1. https://github.com/tiangolo/sqlmodel/blob/088164ef2aa30a21a168f511a998f85c469bba1c/pyproject.toml#L35
2. output from `mamba install` results in error for pydantic version 2:
```text
Encountered problems while solving:
  - package sqlmodel-0.0.8-pyhd8ed1ab_0 requires pydantic >=1.8.2,<2.0.0, but none of the providers can be installed
```